### PR TITLE
Fix SVG as an img detection for Firefox 3

### DIFF
--- a/svgeezy.js
+++ b/svgeezy.js
@@ -52,7 +52,7 @@ var svgeezy = function(){
 		},
 
 		supportsSvg: function(){
-			return document.createElementNS && document.createElementNS( "http://www.w3.org/2000/svg", "svg").createSVGRect;
+			return document.implementation.hasFeature("http://www.w3.org/TR/SVG11/feature#Image", "1.1")
 		}
 	};
 


### PR DESCRIPTION
Detection was not functioning in Firefox 3 as it does support basic SVG functions such as creating a rectangle which was the current detection method.
The new detection method was taken from this very comprehensive article - [Displaying and detecting support for SVG images](http://www.voormedia.nl/blog/2012/10/displaying-and-detecting-support-for-svg-images) - which shows that the current Modernizr method does not correctly report Firefox 3 due to reasons explained before.
