### PR TITLE
Removes 1 un-needed interation

### DIFF
--- a/svgeezy.js
+++ b/svgeezy.js
@@ -29,7 +29,7 @@ window.svgeezy = function() {
 			},
 
 			fallbacks: function() {
-				while(this.imgL--) {
+				while(--this.imgL) {
 					if(!this.hasClass(this.images[this.imgL], this.avoid) || !this.avoid) {
 						var src = this.images[this.imgL].getAttribute('src');
 						if(src === null) {


### PR DESCRIPTION
Since document.getElementsByTagName() will return an array of
elements starting with 0 and length will give the number of
items. The loop in fallbacks() will start iterate over an
element in this.images that doesn't exists.

By changing -- operator to a prefix instead of a suffix
it will now start on an element that actually exists.